### PR TITLE
Automatically start the docker container

### DIFF
--- a/Explorer-Release-Setup-Instructions.md
+++ b/Explorer-Release-Setup-Instructions.md
@@ -53,7 +53,7 @@ $ docker pull storjlabs/storagenode:arm
 - `<storage-dir>`: local directory where you want files to be stored on your hard drive for the network
 
 ```bash
-$ docker run -d -p 28967:28967 \
+$ docker run -d --restart unless-stopped -p 28967:28967 \
     -e WALLET="" \
     -e EMAIL="" \
     -e ADDRESS="" \
@@ -65,7 +65,7 @@ $ docker run -d -p 28967:28967 \
 _For Raspberry Pi and similar ARM-based platforms use:_
 
 ```bash
-$ docker run -d -p 28967:28967 \
+$ docker run -d --restart unless-stopped -p 28967:28967 \
     -e WALLET="" \
     -e EMAIL="" \
     -e ADDRESS="" \


### PR DESCRIPTION
Added `--restart unless-stopped` to the `docker run` command to automatically start the storagenode docker container in case of system restart (manual or due to power outage).

More info about this option is available here: https://docs.docker.com/config/containers/start-containers-automatically/