### PR TITLE
Make Windows Paths more solid

### DIFF
--- a/Explorer-Release-Setup-Instructions.md
+++ b/Explorer-Release-Setup-Instructions.md
@@ -101,7 +101,7 @@ _For Windows Operatins Systems use the following line:_
 ```bash
 $ docker run -d --restart unless-stopped -p 28967:28967 -e WALLET="0xXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" -e EMAIL="user@example.com" -e ADDRESS="domain.ddns.net:28967" -e BANDWIDTH="2TB" -e STORAGE="2TB" -v "<identity-dir>":/app/identity -v "<storage-dir>":/app/config --name storagenode storjlabs/storagenode:alpha
 ```
-- Note: On Windows you need to format the paths like this: `D:\identity\storagenode\` or `D:\data\`
+- Note: On Windows you need to format the paths like this: `D:\\identity\\storagenode\\` or `D:\\data\\`
 
 6) Start your storage node dashboard by running the following command:
 


### PR DESCRIPTION
As Docker on Windows is very picky, it seems like this command is the most solid across all installs so far, sometimes the single backslash works, sometimes it don't.
To make sure that it works, double backslash is the way to go