### PR TITLE
The Explorer release: Add section in how to execute other storagenode commands

### DIFF
--- a/Explorer-Release-Setup-Instructions.md
+++ b/Explorer-Release-Setup-Instructions.md
@@ -223,3 +223,17 @@ $ docker run -d --restart unless-stopped -p 28967:28967 \
     -v "<storage-dir>":/app/config \
     --name storagenode storjlabs/storagenode:arm
 ```
+
+## How to execute other Storage Node commands
+
+While the sotragenode container is running you can
+
+```bash
+$ docker exec -it storagenode /app/storagenode <<command>>
+```
+
+Where `<<command>>` is any of the commands that storagenode has; for knowing them you can execute the command `help`
+
+```bash
+$ docker exec -it storagenode /app/storagenode help
+```

--- a/Explorer-Release-Setup-Instructions.md
+++ b/Explorer-Release-Setup-Instructions.md
@@ -1,35 +1,36 @@
 # The Explorer Release has arrived!
 
-Hello Storj Node Operators! First off, we want to say thank you for your patience. We know many of you have been waiting several months to join the V3 network. Your patience is being rewarded; you are the first nodes to be invited to the Explorer release. 
+Hello Storj Node Operators! First off, we want to say thank you for your patience. We know many of you have been waiting several months to join the V3 network. Your patience is being rewarded; you are the first nodes to be invited to the Explorer release.
 
-This release is gated, which means that we are controlling how many nodes are able to join the network and how quickly they are able to do so. We want to give our early adopters a chance to start earning reputation and STORJ tokens. 
+This release is gated, which means that we are controlling how many nodes are able to join the network and how quickly they are able to do so. We want to give our early adopters a chance to start earning reputation and STORJ tokens.
 
 If we allow too many nodes to join the network right away, you would be earning fewer STORJ tokens because the available data would naturally be spread over a larger number of nodes. Storj Labs is going to be uploading enough data to the network during this release to ensure all storage nodes get payouts.
 
-The goal of this release is to begin building a reliable, long-term supply of storage nodes. The steps in the public alpha are complex and definitely targeted at a more technical audience.  
+The goal of this release is to begin building a reliable, long-term supply of storage nodes. The steps in the public alpha are complex and definitely targeted at a more technical audience.
 
-If these instructions are a little more complex than you can handle, don’t worry! As we progress from alpha to beta, we’ll continually make the process easier and more accessible for less technical users. 
+If these instructions are a little more complex than you can handle, don’t worry! As we progress from alpha to beta, we’ll continually make the process easier and more accessible for less technical users.
 
 Storage node set up tutorial [video](https://youtu.be/cd6gWMgSyqI)
 
 
-#### Important security considerations
+## Important security considerations
 
  * Our software serves requests from the internet, but not all software you may have installed is designed to be exposed to the internet directly! **Do not connect your computer directly to the internet without the assistance of a firewall.** This is especially true for users on Windows with applications responding to requests on all IPs.
 
-#### Before you begin
-Make sure you have an email with your personal single-use authorization token. Note that the format of the authorization token is `email:characterstring`. If you don’t have an authorization token yet, please join our [waitlist](https://storj.io/sign-up-farmer). 
+## Before you begin
+
+Make sure you have an email with your personal single-use authorization token. Note that the format of the authorization token is `email:characterstring`. If you don’t have an authorization token yet, please join our [waitlist](https://storj.io/sign-up-farmer).
 
 *__Note:__ This early release has limited support for some operating systems. If your OS is not explicitly supported, please save your one-time-use authorization token and we will notify everyone when this is no longer an issue.*
 
-Install the necessary dependencies and configure your network appropriately using the following steps: 
+Install the necessary dependencies and configure your network appropriately using the following steps:
 
 - Make sure your computer is *not* connected directly to the internet. If you already have a reasonable router you should be okay. See the Important security considerations section.
-- Install `docker`. Please visit: [docker.com](https://docs.docker.com/install/) and follow the installation guide for your operating system. 
+- Install `docker`. Please visit: [docker.com](https://docs.docker.com/install/) and follow the installation guide for your operating system.
     - _**Note:** Docker Toolbox is not supported_
 - Set up port forwarding & Dynamic DNS! The port you must specify is `28967`. Please visit our [knowledge base article](https://storjlabs.atlassian.net/wiki/spaces/SCKB/pages/4423868/Need+help+port-forwarding) or [portforward.com](https://portforward.com/) and follow the instructions for your router.
 
-#### Setting up your Storage Node on the V3 Network!
+## Setting up your Storage Node on the V3 Network!
 
 *__Note:__ It is highly recommended to perform the following steps local to the machine, and not via a remote connection. If you must use a remote connection, due to the length of time it takes for some of the steps, it is highly recommended to run them inside a virtual console like [TMUX](https://www.hamvocke.com/blog/a-quick-and-easy-guide-to-tmux/) or [SCREEN](https://linuxize.com/post/how-to-use-linux-screen/).*
 
@@ -60,7 +61,7 @@ $ ./identity_darwin_amd64 authorize storagenode <authorization-token>
 
 *__Caution:__ Before proceeding to the next step, please be sure to back up your identity files located in the output path of the previous command. This will allow you to restore your node to working order in case of an unfortunate incident such as a hard drive crash.*
 
-4) Download the docker container from docker hub: 
+4) Download the docker container from docker hub:
 
 ```bash
 $ docker pull storjlabs/storagenode:alpha
@@ -80,7 +81,7 @@ $ docker pull storjlabs/storagenode:alpha
 - Note: If you are using Synology you must add "sudo" in front of commands.
 
 5) Run storage node with the following command, after editing `WALLET`, `EMAIL`, `ADDRESS`, `BANDWIDTH`, `STORAGE`, `<identity-dir>`, and `<storage-dir>`.
-    
+
 - `WALLET`: ethereum address for payments
 - `EMAIL`: email address so that we can notify you when a new version has been released (optional)
 - `ADDRESS`: external IP address or the DDNS you configured and the port you opened on your router `<ip>:<port>`
@@ -143,7 +144,7 @@ $ docker run -d --restart unless-stopped -p 28967:28967 -e WALLET="0xXXXXXXXXXXX
 $ docker exec -it storagenode /app/dashboard.sh
 ```
 
-7) If step 5 or 6 failed for you, run: 
+7) If step 5 or 6 failed for you, run:
 
 ```bash
 $ docker logs -t storagenode
@@ -153,7 +154,7 @@ $ docker logs -t storagenode
 
 *If you need help setting up your storage node, sign up for our [community chat](https://community.storj.io/home) and ask for assistance in the #storagenode channel. Provide your logs and stacktrace when requested by the community leader attending your issue.*
 
-#### Short Maintenance Shutdown
+## Short Maintenance Shutdown
 
 In case you need to shutdown the storagenode for short maintenance on your system, you can shut it down safely with this command:
 ```bash
@@ -164,7 +165,7 @@ After you finished your maintenance you can bring it back up like this:
 $ docker start storagenode
 ```
 
-#### Upgrading your Storage Node
+## Upgrading your Storage Node
 
 You can set up automatic updates for your Storage Node docker container using watchtower with the command below. Watchtower will look for new updates to the docker container on docker hub and automatically update your Storage Node when it sees a new version. This is the best way to ensure your Storage Node stays up to date. The commands below set up watchtower to only monitor the storagenode container and itself. If you want to use watchtower for other containers as well, please refer to the [watchtower documentation](https://hub.docker.com/r/containrrr/watchtower).
 
@@ -177,11 +178,11 @@ For ARM based machines use:
 $ docker run -d --restart=always --name watchtower -v /var/run/docker.sock:/var/run/docker.sock storjlabs/watchtower:latest-arm32v6 storagenode watchtower
 ```
 
-For manual updates run the following commands: 
+For manual updates run the following commands:
 
 1) Stop the running storagenode container by running the following command:
 ```bash
-$ docker stop storagenode 
+$ docker stop storagenode
 ```
 
 2) Remove the existing container by running the following command:


### PR DESCRIPTION
I added a section in to inform how to execute other storagenode commands.

I also changed the section level to follow the order, however if the 4th level was the one wanted rather than the 2nd one, do let me know and I will drop that commit.