### PR TITLE
Code: Style add zeebo/errs usage

### DIFF
--- a/code/Style.md
+++ b/code/Style.md
@@ -107,7 +107,7 @@ func (reg *Registry) GetUser(ctx context.Context, username string) (*User, error
 		return nil, ErrUser.New("not found %s", username)
 	}
 	if err != nil {
-		return nil, ErrUser.Wrap(err)
+		return nil, Error.Wrap(err)
 	}
 
 	return user, nil

--- a/code/Style.md
+++ b/code/Style.md
@@ -241,24 +241,6 @@ Cognitive load at 5 arguments is quite high already, so at that moment prefer co
 
 _Exclude `ctx` and `log` from the count of 5, since common arguments don't have as drastic effect._
 
-## Struct types constructors
-
-Constructor functions of struct types must always return a pointer to the type rather than a value.
-
-```go
-
-type User struct {
-	Username string
-}
-
-func NewUser(username string) *User {
-	return &User{
-		Username: username,
-	}
-}
-
-```
-
 ## Package naming and aliases
 
 For package naming see https://blog.golang.org/package-names. Prefer names that are easy to say when talking.

--- a/code/Style.md
+++ b/code/Style.md
@@ -241,6 +241,24 @@ Cognitive load at 5 arguments is quite high already, so at that moment prefer co
 
 _Exclude `ctx` and `log` from the count of 5, since common arguments don't have as drastic effect._
 
+## Struct types constructors
+
+Constructor functions of struct types must always return a pointer to the type rather than a value.
+
+```go
+
+type User struct {
+	Username string
+}
+
+func NewUser(username string) *User {
+	return &User{
+		Username: username,
+	}
+}
+
+```
+
 ## Package naming and aliases
 
 For package naming see https://blog.golang.org/package-names. Prefer names that are easy to say when talking.

--- a/code/Style.md
+++ b/code/Style.md
@@ -72,6 +72,28 @@ func Example() (err error) {
 }
 ```
 
+Sometimes, there are situations where a function, calls another function that only needs to return the value or the error returned by the call; when the called function return errors not created or wrapped by `errs` package the error must be  wrapped or annotated, however it isn't needed to have a conditional to achieve such purpose, because the functions that `errs` package have ignore the `nil` value when they are passed through; for example
+
+```go
+func OpenDataFile(filename string) (*os.File, error) {
+	file, err := os.Open(filepath.Join("data", filename))
+	if err != nil {
+		return nil, Error.Wrap(err)
+	}
+
+	return file, nil
+}
+```
+
+should be written like
+
+```go
+func OpenDataFile(filename string) (*os.File, error) {
+	file, err := os.Open(filepath.Join("data", filename))
+	return file, errs.Wrap(err)
+}
+```
+
 ## Comments
 
 See [Comment Sentences](https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences). Comments should help the reader to orient to the constraints and relations with other packages.

--- a/code/Style.md
+++ b/code/Style.md
@@ -94,6 +94,26 @@ func OpenDataFile(filename string) (*os.File, error) {
 }
 ```
 
+### Conditionals for _Not Found_ error values
+
+It's pretty common in Go to find functions that return an error when a function should return a value but such value "isn't found". The most classic example of this is the [`sql.ErrNoRows`](https://golang.org/pkg/database/sql/#pkg-variables) which may be returned by function like [`sql#DB.QueryRow`](https://golang.org/pkg/database/sql/#DB.QueryRow). Under this circumstances we first check for such error and if it doesn't match then we do a second check for non `nil` error, rather than nesting them.
+
+```go
+var ErrUser = errs.Class("user")
+
+func (reg *Registry) GetUser(ctx context.Context, username string) (*User, error) {
+	user, := reg.db.Get_User_By_Username(ctx, username)
+	if err == sql.ErrNoRows {
+		return nil, ErrUser.New("not found %s", username)
+	}
+	if err != nil {
+		return nil, Error.Wrap(err)
+	}
+
+	return user, nil
+}
+```
+
 ## Comments
 
 See [Comment Sentences](https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences). Comments should help the reader to orient to the constraints and relations with other packages.

--- a/code/Style.md
+++ b/code/Style.md
@@ -144,7 +144,7 @@ Avoid using global loggers (e.g. `zap.L().Error`, `log.Print`, `fmt.Print`), unl
 
 ## Variable naming
 
-Prefer hard-to-confuse variables with 3-7 letters. Use conventional naming when there is one (e.g. `mu sync.Mutex`) 
+Prefer hard-to-confuse variables with 3-7 letters. Use conventional naming when there is one (e.g. `mu sync.Mutex`)
 
 Small variables can be fine in small scopes (up to 40 lines) and when there isn't a danger of confusion. Take into account that the confusion can arise also due to moving between packages. As an example:
 
@@ -250,7 +250,7 @@ Of course using sleeps, tickers for scheduling or for avoiding thundering herd p
 
 ## Mutexes
 
-When using synchronizing structures like mutexes or condition variables organize them in the struct such that they make clear which fields are protected and which are unprotected. 
+When using synchronizing structures like mutexes or condition variables organize them in the struct such that they make clear which fields are protected and which are unprotected.
 
 For example:
 

--- a/code/Style.md
+++ b/code/Style.md
@@ -107,7 +107,7 @@ func (reg *Registry) GetUser(ctx context.Context, username string) (*User, error
 		return nil, ErrUser.New("not found %s", username)
 	}
 	if err != nil {
-		return nil, Error.Wrap(err)
+		return nil, ErrUser.Wrap(err)
 	}
 
 	return user, nil

--- a/code/Style.md
+++ b/code/Style.md
@@ -48,7 +48,7 @@ All errors must be handled and checked. Don't hide errors.
 
 _Exceptions: printing to console or log (e.g. `fmt.Println`, `log.Print`)_
 
-For error handling we lean on the package [github.com/zeebo/errs](https://godoc.org/github.com/zeebo/errs) for adding call stack traces and annoate them.
+For error handling we lean on the package [github.com/zeebo/errs](https://godoc.org/github.com/zeebo/errs) for adding call stack traces and annotate them.
 
 Use `errs.Class` to annotate errors with more information.
 

--- a/code/Style.md
+++ b/code/Style.md
@@ -48,6 +48,8 @@ All errors must be handled and checked. Don't hide errors.
 
 _Exceptions: printing to console or log (e.g. `fmt.Println`, `log.Print`)_
 
+For error handling we lean on the package [github.com/zeebo/errs](https://godoc.org/github.com/zeebo/errs) for adding call stack traces and annoate them.
+
 Use `errs.Class` to annotate errors with more information.
 
 To combine multiple errors use `errs.Combine`. To collect multiple similar errors use `errs.Group`.

--- a/code/Style.md
+++ b/code/Style.md
@@ -72,9 +72,9 @@ func Example() (err error) {
 }
 ```
 
-There are __2 exceptions__ when an error **NEVER MUST BE** wrapped nor annotated nor combined:
+There are __a few exceptions__ when an error **NEVER MUST BE** wrapped nor annotated nor combined:
 
-1. Those functions which return the [`io.EOF`](https://golang.org/pkg/io/#pkg-variables) to indicate that they have finished and they don't have to be called again, like the types which implement the [`io.Reader` interface](https://golang.org/pkg/io/#Reader).
+1. Those functions which return the sentinel errors for indicating specific statuses. For example, the [`io.EOF`](https://golang.org/pkg/io/#pkg-variables) which is expected to be returned by [`io.Reader` interface](https://golang.org/pkg/io/#Reader) implementations.
 2. Some packages which require that user specific functions return specific error types for acting appropriately, like [_gRPC status](https://godoc.org/google.golang.org/grpc/status) for being able to respond a [specific protocol error status code](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md).
 
 

--- a/code/Style.md
+++ b/code/Style.md
@@ -81,6 +81,8 @@ There are __2 exceptions__ when an error **NEVER MUST BE** wrapped nor annotated
 On the other hand Sometimes, there are situations where a function, calls another function that only needs to return the value or the error returned by the call; when the called function return errors not created or wrapped by `errs` package the error must be  wrapped or annotated, however it isn't needed to have a conditional to achieve such purpose, because the functions that `errs` package have ignore the `nil` value when they are passed through; for example
 
 ```go
+var Error = errs.Class("data")
+
 func OpenDataFile(filename string) (*os.File, error) {
 	file, err := os.Open(filepath.Join("data", filename))
 	if err != nil {
@@ -94,9 +96,11 @@ func OpenDataFile(filename string) (*os.File, error) {
 should be written like
 
 ```go
+var Error = errs.Class("data")
+
 func OpenDataFile(filename string) (*os.File, error) {
 	file, err := os.Open(filepath.Join("data", filename))
-	return file, errs.Wrap(err)
+	return file, Error.Wrap(err)
 }
 ```
 

--- a/code/Style.md
+++ b/code/Style.md
@@ -72,7 +72,13 @@ func Example() (err error) {
 }
 ```
 
-Sometimes, there are situations where a function, calls another function that only needs to return the value or the error returned by the call; when the called function return errors not created or wrapped by `errs` package the error must be  wrapped or annotated, however it isn't needed to have a conditional to achieve such purpose, because the functions that `errs` package have ignore the `nil` value when they are passed through; for example
+There are __2 exceptions__ when an error **NEVER MUST BE** wrapped nor annotated nor combined:
+
+1. Those functions which return the [`io.EOF`](https://golang.org/pkg/io/#pkg-variables) to indicate that they have finished and they don't have to be called again, like the types which implement the [`io.Reader` interface](https://golang.org/pkg/io/#Reader).
+2. Some packages which require that user specific functions return specific error types for acting appropriately, like [_gRPC status](https://godoc.org/google.golang.org/grpc/status) for being able to respond a [specific protocol error status code](https://github.com/grpc/grpc/blob/master/doc/statuscodes.md).
+
+
+On the other hand Sometimes, there are situations where a function, calls another function that only needs to return the value or the error returned by the call; when the called function return errors not created or wrapped by `errs` package the error must be  wrapped or annotated, however it isn't needed to have a conditional to achieve such purpose, because the functions that `errs` package have ignore the `nil` value when they are passed through; for example
 
 ```go
 func OpenDataFile(filename string) (*os.File, error) {

--- a/code/Style.md
+++ b/code/Style.md
@@ -94,26 +94,6 @@ func OpenDataFile(filename string) (*os.File, error) {
 }
 ```
 
-### Conditionals for _Not Found_ error values
-
-It's pretty common in Go to find functions that return an error when a function should return a value but such value "isn't found". The most classic example of this is the [`sql.ErrNoRows`](https://golang.org/pkg/database/sql/#pkg-variables) which may be returned by function like [`sql#DB.QueryRow`](https://golang.org/pkg/database/sql/#DB.QueryRow). Under this circumstances we first check for such error and if it doesn't match then we do a second check for non `nil` error, rather than nesting them.
-
-```go
-var ErrUser = errs.Class("user")
-
-func (reg *Registry) GetUser(ctx context.Context, username string) (*User, error) {
-	user, := reg.db.Get_User_By_Username(ctx, username)
-	if err == sql.ErrNoRows {
-		return nil, ErrUser.New("not found %s", username)
-	}
-	if err != nil {
-		return nil, Error.Wrap(err)
-	}
-
-	return user, nil
-}
-```
-
 ## Comments
 
 See [Comment Sentences](https://github.com/golang/go/wiki/CodeReviewComments#comment-sentences). Comments should help the reader to orient to the constraints and relations with other packages.


### PR DESCRIPTION
~While doing some reviews, I found some lines where I asked about if they were conventions in Storj, some of them because the style looked odd to me, others where believing that we mostly prefer explicit code than shorter one looked the opposite to that and others because the response was more like something that we apply mechanically without thinking the semantics.~

~The responses haven't been 100% affirmative that they should be in this way, but they could be based on the current code base, hence my way to find out if they are actually conventions or not has been to open this PR and have a review for it.~

~NOTE that each commit contain a specific thing, so if some of them turned to be agreed to be added but not all of them, it should be easy to drop some commit.~

~References on each one added [commit - link]:~

* ~8095055 - https://github.com/storj/storj/pull/1972#discussion_r285583149~
* ~0033cb4 - https://github.com/storj/storj/pull/1972#discussion_r285629766~
* ~30c28bb - https://github.com/storj/storj/pull/1972#discussion_r285090510~

The ones commented here that aren't seen as a convention have been removed and now the PR only contains:

* Mention the package that we use for wrapping and annotating errors, github.com/zeebo/errs.
* Add the case where we avoid errors conditionals when the errors must be only wrapped or annotated by zeebo/errs package.

In order of unblocking these changes of getting merged due to the controversial of the rest.