### PR TITLE
Explorer-release-setup-instructions: Replace volume binding with mount

### DIFF
--- a/Explorer-Release-Setup-Instructions.md
+++ b/Explorer-Release-Setup-Instructions.md
@@ -87,8 +87,8 @@ $ docker pull storjlabs/storagenode:alpha
    - Note: If you are using a custom port other than 28967, then you have to change the `-p 28967:28967` to `-p <port>:28967`
 - `BANDWIDTH`: how much bandwidth you want to allocate to the Storj network
 - `STORAGE`: how much disk space you want to allocate to the Storj network
-- `<identity-dir>`: the location of your identity files. You can copy the absolute path from the output of the identity commands you ran earlier
-- `<storage-dir>`: local directory where you want files to be stored on your hard drive for the network
+- `<identity-dir>`: replace to the location of your identity files. You can copy the absolute path from the output of the identity commands you ran earlier
+- `<storage-dir>`: replace to the local directory where you want files to be stored on your hard drive for the network
    - Note: the current database backend is [BoltDB](https://github.com/boltdb/bolt), which [requires _mmap_](https://github.com/boltdb/bolt/issues/704), hence you have use file system which supports _mmap_.
 
 ```bash
@@ -98,8 +98,8 @@ $ docker run -d --restart unless-stopped -p 28967:28967 \
     -e ADDRESS="domain.ddns.net:28967" \
     -e BANDWIDTH="2TB" \
     -e STORAGE="2TB" \
-    -v "<identity-dir>":/app/identity \
-    -v "<storage-dir>":/app/config \
+    --mount type=bind,source="<identity-dir>",destination=/app/identity \
+    --mount type=bind,source="<storage-dir>",destination=/app/config \
     --name storagenode storjlabs/storagenode:alpha
 ```
 
@@ -112,8 +112,8 @@ $ docker run -d --restart unless-stopped -p 28967:28967 \
     -e ADDRESS="domain.ddns.net:28967" \
     -e BANDWIDTH="2TB" \
     -e STORAGE="2TB" \
-    -v "<identity-dir>":/app/identity \
-    -v "<storage-dir>":/app/config \
+    --mount type=bind,source="<identity-dir>",destination=/app/identity \
+    --mount type=bind,source="<storage-dir>",destination=/app/config \
     --name storagenode storjlabs/storagenode:arm
 ```
 
@@ -126,8 +126,8 @@ $ docker run -d --restart unless-stopped -p 28967:28967 \
     -e ADDRESS="domain.ddns.net:28967" \
     -e BANDWIDTH="2TB" \
     -e STORAGE="2TB" \
-    -v "<identity-dir>":/app/identity \
-    -v "<storage-dir>":/app/config \
+    --mount type=bind,source="<identity-dir>",destination=/app/identity \
+    --mount type=bind,source="<storage-dir>",destination=/app/config \
     --name storagenode storjlabs/storagenode:alpha
 ```
 - Note: If you are using Synology you must add "sudo" in front of commands.
@@ -207,8 +207,8 @@ $ docker run -d --restart unless-stopped -p 28967:28967 \
     -e ADDRESS="" \
     -e BANDWIDTH="2TB" \
     -e STORAGE="2TB" \
-    -v "<identity-dir>":/app/identity \
-    -v "<storage-dir>":/app/config \
+    --mount type=bind,source="<identity-dir>",destination=/app/identity \
+    --mount type=bind,source="<storage-dir>",destination=/app/config \
     --name storagenode storjlabs/storagenode:alpha
 ```
 For ARM based machines use:
@@ -219,7 +219,7 @@ $ docker run -d --restart unless-stopped -p 28967:28967 \
     -e ADDRESS="" \
     -e BANDWIDTH="2TB" \
     -e STORAGE="2TB" \
-    -v "<identity-dir>":/app/identity \
-    -v "<storage-dir>":/app/config \
+    --mount type=bind,source="<identity-dir>",destination=/app/identity \
+    --mount type=bind,source="<storage-dir>",destination=/app/config \
     --name storagenode storjlabs/storagenode:arm
 ```


### PR DESCRIPTION
The difference between them: https://docs.docker.com/storage/bind-mounts/#differences-between--v-and---mount-behavior

Because the -v and --volume flags have been a part of Docker for a long time, their behavior cannot be changed. This means that *there is one behavior that is different between -v and --mount*.

If you use -v or --volume to bind-mount a file or directory that does not yet exist on the Docker host, -v creates the endpoint for you. *It is always created as a directory*.

If you use --mount to bind-mount a file or directory that does not yet exist on the Docker host, Docker does not automatically create it for you, but generates an error.

This should save our SNO on Windows and MacOS from losing data during bugs in docker itself, when it doesn't map the data folder from the host to the container and just creates the data mountpoint without an error.