### PR TITLE
Explorer-Release-Inst: Use same format for Windows

### DIFF
--- a/Explorer-Release-Setup-Instructions.md
+++ b/Explorer-Release-Setup-Instructions.md
@@ -133,8 +133,17 @@ $ docker run -d --restart unless-stopped -p 28967:28967 \
 - Note: If you are using Synology you must add "sudo" in front of commands.
 
 _For Windows Operating Systems use the following line:_
+
 ```bash
-$ docker run -d --restart unless-stopped -p 28967:28967 -e WALLET="0xXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" -e EMAIL="user@example.com" -e ADDRESS="domain.ddns.net:28967" -e BANDWIDTH="2TB" -e STORAGE="2TB" --mount type=bind,source="<identity-dir>",destination=/app/identity --mount type=bind,source="<storage-dir>",destination=/app/config --name storagenode storjlabs/storagenode:alpha
+$ docker run -d --restart unless-stopped -p 28967:28967 \
+    -e WALLET="0xXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" \
+    -e EMAIL="user@example.com" \
+    -e ADDRESS="domain.ddns.net:28967" \
+    -e BANDWIDTH="2TB" \
+    -e STORAGE="2TB"\
+    --mount type=bind,source="<identity-dir>",destination=/app/identity \
+    --mount type=bind,source="<storage-dir>",destination=/app/config \
+    --name storagenode storjlabs/storagenode:alpha
 ```
 - Note: On Windows you need to format the paths like this: `D:\\identity\\storagenode\\` or `D:\\data\\`
 


### PR DESCRIPTION
Update the format of running the docker container on Windows to be the
same than the used for other platforms.