### PR TITLE
Point download links for S3 Gateway to latest release

### DIFF
--- a/S3-Gateway.md
+++ b/S3-Gateway.md
@@ -10,12 +10,12 @@ One gateway is already included in the [test network](Test-network.md), so you n
 
 First, if you haven't already followed the preparation steps in https://github.com/storj/storj/wiki/Vanguard-Release-Setup-Instructions, please do so.
 
-Next, Download the correct binary for your operating system:
+Next, download the correct binary for your operating system:
 
-- Mac OS: [gateway_darwin_amd64.zip](https://github.com/storj/storj/releases/download/v0.16.1/gateway_darwin_amd64.zip)
-- Linux: [gateway_linux_amd64.zip](https://github.com/storj/storj/releases/download/v0.16.1/gateway_linux_amd64.zip)
-- Raspberry Pi: [gateway_linux_arm.zip](https://github.com/storj/storj/releases/download/v0.16.1/gateway_linux_arm.zip)
-- Windows Pro: [gateway_windows_amd64.zip](https://github.com/storj/storj/releases/download/v0.16.1/gateway_windows_amd64.exe.zip)
+- Mac OS: [gateway_darwin_amd64.zip](https://github.com/storj/storj/releases/latest/download/gateway_darwin_amd64.zip)
+- Linux: [gateway_linux_amd64.zip](https://github.com/storj/storj/releases/latest/download/gateway_linux_amd64.zip)
+- Raspberry Pi: [gateway_linux_arm.zip](https://github.com/storj/storj/releases/latest/download/gateway_linux_arm.zip)
+- Windows: [gateway_windows_amd64.exe.zip](https://github.com/storj/storj/releases/latest/download/gateway_windows_amd64.exe.zip)
 
 Setup your gateway by running the following command and following the wizard:
 


### PR DESCRIPTION
The download links to S3 Gateway binaries are almost always out-of-date. This PR replaces them with static links to the latest release in Github.