### PR TITLE
code: Services must not depend on transports

### DIFF
--- a/code/Service.md
+++ b/code/Service.md
@@ -4,6 +4,8 @@ Services handle internal peer logic. Services use databases or other services to
 
 Services do not have a life-cycle, usually, which means they must be explicitly shut down. It should be safe to run the same service concurrently in the same process or multiple processes.
 
+Services must not depend on trasport implementations, [Endpoints](Endpoint.md) must deal with them.
+
 ## Adding a new service
 
 To add a new service there are few steps:
@@ -20,7 +22,7 @@ To add a new service there are few steps:
 
 A basic service implementation looks like:
 
-```
+```go
 package orders
 
 import (
@@ -71,6 +73,8 @@ func NewService(
 }
 
 // VerifyOrderLimitSignature verifies that the signature inside order limit belongs to the satellite.
+//
+// NOTE it accepts pb.OrderLimit becase it uses its serialization to verify the signature.
 func (service *Service) VerifyOrderLimitSignature(ctx context.Context, signed *pb.OrderLimit) (err error) {
 	defer mon.Task()(&ctx)(&err)
 	return signing.VerifyOrderLimitSignature(ctx, service.satellite, signed)

--- a/code/Service.md
+++ b/code/Service.md
@@ -4,7 +4,7 @@ Services handle internal peer logic. Services use databases or other services to
 
 Services do not have a life-cycle, usually, which means they must be explicitly shut down. It should be safe to run the same service concurrently in the same process or multiple processes.
 
-Services must not depend on trasport implementations, [Endpoints](Endpoint.md) must deal with them.
+Arguments to / return values from services should be hand-crafted Go types, rather than generated protobuf types. Exceptions for this are types that require signatures. This is to ensure that services aren't tied to a specific transport implementation.
 
 ## Adding a new service
 

--- a/code/Service.md
+++ b/code/Service.md
@@ -74,7 +74,7 @@ func NewService(
 
 // VerifyOrderLimitSignature verifies that the signature inside order limit belongs to the satellite.
 //
-// NOTE it accepts pb.OrderLimit becase it uses its serialization to verify the signature.
+// NOTE it accepts pb.OrderLimit because it uses its serialization to verify the signature.
 func (service *Service) VerifyOrderLimitSignature(ctx context.Context, signed *pb.OrderLimit) (err error) {
 	defer mon.Task()(&ctx)(&err)
 	return signing.VerifyOrderLimitSignature(ctx, service.satellite, signed)


### PR DESCRIPTION
Add to the requirements of service that they must not depend on
transport implementations.

As commented, we should update the example for showing a service which doesn't have any dependency with protocol buffers and make the people raise the point when they find an exception, however right now, I didn't have a good and concise example to replace with.