### PR TITLE
update protobuf docs somewhat

### DIFF
--- a/code/Protobuf.md
+++ b/code/Protobuf.md
@@ -4,19 +4,19 @@ This document outlines the steps for creating or modifying a protobuf.
 
 ## Requirements
 
-- Install GRPC.
+- Install the protoc compiler that is used to generate protobuf code and gRPC service code, `protoc`, by downloading the binary https://github.com/protocolbuffers/protobuf/releases.  Then move `protoc` to `/usr/local/bin/` and also move `protoc/include` to `/usr/local/include/`. Alternately, you can install protoc using the appropriate package for your OS:
 
-`$ go get -u google.golang.org/grpc`
+  - Debian/Ubuntu/derivatives:
 
-- Install the protoc compiler that is used to generate gRPC service code, `protoc` by downloading the binary https://github.com/protocolbuffers/protobuf/releases.  Then move `protoc` to `/usr/local/bin/` and also move `protoc/include` to `/usr/local/include/`.
+      apt install protobuf-compiler
 
-- Install protoc plugin for Go, [`proto-gen-go`](https://github.com/golang/protobuf#installation):
+  - MacOS with Homebrew:
 
-`$ go get -u github.com/golang/protobuf/protoc-gen-go`
+      brew install protobuf
 
-- Install [`protolock`](https://github.com/nilslice/protolock):
+- Install a protobuf specification linter, the protolock tool, and their dependencies. (This step is idempotent, so run it again if you're not sure whether your tools need updating):
 
-`$ go get -u github.com/nilslice/protolock/...`
+    $ go run scripts/protobuf.go install
 
 ## Steps to Modify `.proto` Files
 
@@ -24,12 +24,16 @@ Assumes all steps occur from the home directory of the https://github.com/storj/
 
 1. Modify the `.proto` file
 
-2. From the `pkg/pb/` directory run the following command:
+2. To update the generated code related to your `.proto` file changes, use `go generate` on the pb directory:
 
-`$ go generate`
+    $ go generate ./pkg/pb/...
 
-3. If a check that fails when there's a breaking API change, this command may need to be executed to override:
+3. Update the proto.lock file to match your changes:
 
-`$ protolock commit --force`
+    $ protolock commit
 
-** Note: overriding the breaking API is only allowed during alpha/beta development.
+4. If step 3 fails with an error, your changes are not backward compatible! You should fix that, because we need to maintain backward compatibility so that versions of storagenode/satellite/uplink/etc built at different times can still communicate with each other. We should not break backward compatibility without _very_ careful investigation of the ramifications. If we are sure that the change is still ok, you can use the `--force` argument to protolock to override its complaint:
+
+    $ protolock commit --force
+
+5. Add the new `proto.lock` file to your branch and include it in your PR or changeset. If you forget the protolock steps, lint will complain and fail the build.

--- a/code/Protobuf.md
+++ b/code/Protobuf.md
@@ -32,7 +32,7 @@ Assumes all steps occur from the home directory of the https://github.com/storj/
 
     $ protolock commit
 
-4. If step 3 fails with an error, your changes are not backward compatible! You should fix that, because we need to maintain backward compatibility so that versions of storagenode/satellite/uplink/etc built at different times can still communicate with each other. We should not break backward compatibility without _very_ careful investigation of the ramifications. If we are sure that the change is still ok, you can use the `--force` argument to protolock to override its complaint:
+4. If step 3 fails with an error, your changes are not backward compatible! You should fix that, because we need to maintain backward compatibility so that versions of storagenode/satellite/uplink/etc built at different times can still communicate with each other. We should not break backward compatibility without _very_ careful investigation of the ramifications. For example, a backward-incompatible change might be fine if none of the protobufs are actually used for communication between any existing system components yet. If we are sure that the change is still ok, you can use the `--force` argument to protolock to override its complaint:
 
     $ protolock commit --force
 


### PR DESCRIPTION
I think installation by way of scripts/protobuf.go is the best approach
right now, because it will keep everyone on the same versions of the
underlying modules.

Expand discussion of `protolock commit` a little bit now that we're in
all-grown-up no-more-backwards-incompatibilities land.