### PR TITLE
initial docs on static port allocations for edge services

### DIFF
--- a/code/PortAllocations.md
+++ b/code/PortAllocations.md
@@ -1,0 +1,17 @@
+# Static Service Port Allocations
+Default network ports should be assigned, and documented here. Most services
+expose more than one port, make sure to include them here and document their
+separate usage.
+
+| Service | Port | Usage |
+|---|---|---|
+| authservice | 13000 | http api |
+| authservice | 13001 | https api |
+| authservice | 13002 | drpc api |
+| authservice | 13099 | go debug |
+| gateway | 13100 | http api |
+| gateway | 13101 | https api |
+| gateway | 13199 | go debug |
+| linksharing | 13200 | http api |
+| linksharing | 13201 | https api |
+| linksharing | 13299 | go debug |


### PR DESCRIPTION
wording could use improvement, assignment of the top of the allocation block to the debug port is arbitrary. feedback much appreciated!