### PR TITLE
multipart-part-size.md: Clarify the correct AWS config flag

### DIFF
--- a/docs/api-reference/s3-compatible-gateway/multipart-upload/multipart-part-size.md
+++ b/docs/api-reference/s3-compatible-gateway/multipart-upload/multipart-part-size.md
@@ -29,6 +29,6 @@ All of these parts are broken into one or more Segments by the Storj DCS Gateway
 If you are using the Amazon AWS CLI, you can configure it to use a larger part threshold as follows:
 
 ```
-aws configure set default.s3.multipart_threshold 64MB
+aws configure set default.s3.multipart_chunksize 64MB
 ```
 


### PR DESCRIPTION
multipart_threshold actually refers to maximum size of a file when AWS cli switches to using multipart requests (instead of a single API call).
The correct config flag to use is multipart_chunksize

See https://docs.aws.amazon.com/cli/latest/topic/s3-config.html#multipart-threshold