### PR TITLE
Remove steps about using full strict with Cloudflare

### DIFF
--- a/app/dcs/code/static-site-hosting/custom-domains/page.md
+++ b/app/dcs/code/static-site-hosting/custom-domains/page.md
@@ -153,7 +153,7 @@ While Linksharing links are secure, when you use a custom domain the browser is 
 
 ### Why am I seeing an "Invalid SSL certificate" error from Cloudflare?
 
-Problem: Customers using Cloudflare (or likely anything as a reverse proxy) who have certain TLS settings may see an error. In an effort to improve security and bring users SSL certs without the need for a CDN proxy, we no longer support self-signed certificates for custom domains. Keep reading for two ways to resolve the problem.
+Problem: Customers using Cloudflare (or likely anything as a reverse proxy) who have certain TLS settings may see an error. In an effort to improve security and bring users SSL certs without the need for a CDN proxy, we no longer support self-signed certificates for custom domains.
 
 ![Cloudflare Invalid SSL Certificate Error](https://link.storjshare.io/raw/jua7rls6hkx5556qfcmhrqed2tfa/docs/images/dsxcEfc44l_gwzQHRiRKS_167760201695824623.png)
 

--- a/app/dcs/code/static-site-hosting/custom-domains/page.md
+++ b/app/dcs/code/static-site-hosting/custom-domains/page.md
@@ -157,11 +157,9 @@ Problem: Customers using Cloudflare (or likely anything as a reverse proxy) who 
 
 ![Cloudflare Invalid SSL Certificate Error](https://link.storjshare.io/raw/jua7rls6hkx5556qfcmhrqed2tfa/docs/images/dsxcEfc44l_gwzQHRiRKS_167760201695824623.png)
 
-**Solution 1: Update your Cloudflare SSL/TLS encryption mode to "Flexible"**
+**Solution: Update your Cloudflare SSL/TLS encryption mode to "Flexible"**
 
 ![Cloudflare Flexible SSL/TLS encryption](https://link.storjshare.io/raw/jua7rls6hkx5556qfcmhrqed2tfa/docs/images/Y_EKNdQvTeG-lHQ52HbX9_image.png)
-
-**Solution 2: Follow the steps above for [](docId:RI4zz1sLvVEZ4ZcZbuT7l)** (Pro Accounts only) - this will enable you to use the "Full (strict)" option with Cloudflare
 
 ### How do I verify my custom domain?
 


### PR DESCRIPTION
We are suggesting users to enable strict mode with custom domains and Linksharing TLS. This won't work, because we require that you don't proxy at all if using Linksharing TLS, otherwise certificate creation/renewal challenges will fail.

It sort of works if you first create the certificate on Linksharing, _then_ change Cloudflare to proxy and set the mode to strict, but this is not reliable because it will fail in 3 months when the certificate is attempted to be renewed.

I will add a new dedicated section about using Cloudflare and other proxies with Linksharing TLS in another change.