### PR TITLE
updated links to 2.1.0.5 versions of Docker Desktop

### DIFF
--- a/app/node/get-started/install-node-software/cli/docker/page.md
+++ b/app/node/get-started/install-node-software/cli/docker/page.md
@@ -26,9 +26,9 @@ What we use to package the Storage Node software and push new updates. To set up
 [**MacOS Docker Installation**](https://docs.docker.com/docker-for-mac/install/)
 
 {% callout type="danger"  %}
-Please, install version **2.1.0.5**: [Docker Desktop Community](https://docs.docker.com/docker-for-mac/release-notes/#docker-desktop-community-2105)
+Please, install version **2.1.0.5** if you have any issues with the newest version: [Docker Desktop Community 2.1.0.5 (for x86-64 processors only)](https://download.docker.com/mac/stable/40693/Docker.dmg).
 
-All newer versions have various issues, such as losing network connection, have false disk errors and so on as described in this thread: [Nodes offline for 3/4 days. Is it possible to recover?](https://forum.storj.io/t/nodes-offline-for-3-4-days-is-it-possible-to-recover/11697/16?u=alexey)
+As far as we know all newer versions have various issues, such as losing network connection, have false disk errors and so on as described in this thread: [Nodes offline for 3/4 days. Is it possible to recover?](https://forum.storj.io/t/nodes-offline-for-3-4-days-is-it-possible-to-recover/11697/16?u=alexey)
 {% /callout %}
 
 {% callout type="warning"  %}
@@ -41,9 +41,9 @@ All newer versions have various issues, such as losing network connection, have 
 [Windows Docker Installation](https://docs.docker.com/docker-for-windows/install/#install-docker-desktop-for-windows-desktop-app)
 
 {% callout type="danger"  %}
-Please, install version **2.1.0.5** if your Windows doesn't support WSL2: [Docker Desktop Community](https://docs.docker.com/docker-for-mac/release-notes/#docker-desktop-community-2105)
+Please, install version **2.1.0.5** if your Windows doesn't support WSL2 and you have any issues in a newest version: [Docker Desktop Community 2.1.0.5](https://download.docker.com/win/stable/40693/Docker%20Desktop%20Installer.exe).
 
-All newer versions for Hyper-V have various issues, such as losing network connection as described in this thread:[ Latest Docker Desktop for Windows compatibility?](https://forum.storj.io/t/latest-docker-desktop-for-windows-compatibility/6045)
+As far as we know all newer versions for Hyper-V have various issues, such as losing network connection as described in this thread:[ Latest Docker Desktop for Windows compatibility?](https://forum.storj.io/t/latest-docker-desktop-for-windows-compatibility/6045)
 {% /callout %}
 
 {% callout type="warning"  %}


### PR DESCRIPTION
Docker removed direct links from their release notes page, and now it's not possible to find downloads for older version in their documentation