### PR TITLE
Clean up use of base-url and auth-service in command examples

### DIFF
--- a/app/dcs/api/uplink-cli/access-command/access-inspect-command/page.md
+++ b/app/dcs/api/uplink-cli/access-command/access-inspect-command/page.md
@@ -29,7 +29,6 @@ uplink access inspect [ACCESS-GRANT] [flags]
 
 | Flag              | Description                                         |
 | :---------------- | :-------------------------------------------------- |
-| `--access string` | the serialized access, or name of the access to use |
 | `--help`,` -h`    | help for inspect                                    |
 
 ## Examples

--- a/app/dcs/api/uplink-cli/access-command/access-register/page.md
+++ b/app/dcs/api/uplink-cli/access-command/access-register/page.md
@@ -29,7 +29,6 @@ uplink access register <flags> <ACCESS-GRANT>
 
 | Flag                    | Description                                                                                          |
 | :---------------------- | :--------------------------------------------------------------------------------------------------- |
-| `--access string`       | the serialized access, or name of the access to use                                                  |
 | `--auth-service string` | the address to the service you wish to register your access with (default "auth.storjshare.io:7777") |
 | `--public`              | if the access should be public. Default false                                                        |
 

--- a/app/dcs/api/uplink-cli/access-command/access-register/page.md
+++ b/app/dcs/api/uplink-cli/access-command/access-register/page.md
@@ -27,11 +27,11 @@ uplink access register <flags> <ACCESS-GRANT>
 
 ## Flags
 
-| Flag                    | Description                                                      |
-| :---------------------- | :--------------------------------------------------------------- |
-| `--access string`       | the serialized access, or name of the access to use              |
-| `--auth-service string` | the address to the service you wish to register your access with |
-| `--public`              | if the access should be public. Default false                    |
+| Flag                    | Description                                                                                          |
+| :---------------------- | :--------------------------------------------------------------------------------------------------- |
+| `--access string`       | the serialized access, or name of the access to use                                                  |
+| `--auth-service string` | the address to the service you wish to register your access with (default "auth.storjshare.io:7777") |
+| `--public`              | if the access should be public. Default false                                                        |
 
 ## Example
 

--- a/app/dcs/api/uplink-cli/setup-command/page.md
+++ b/app/dcs/api/uplink-cli/setup-command/page.md
@@ -27,11 +27,11 @@ uplink setup [flags]
 
 ## Flags
 
-| Flag                    | Description                                                                                 |
-| :---------------------- | :------------------------------------------------------------------------------------------ |
-| `--auth-service string` | If generating backwards-compatible S3 Gateway credentials, use this auth service (default ) |
-| `-f`, `--force`         | Force overwrite an existing saved access                                                    |
-| `--use`                 | Switch the default access to the newly created one                                          |
+| Flag                    | Description                                                                                                             |
+| :---------------------- | :---------------------------------------------------------------------------------------------------------------------- |
+| `--auth-service string` | If generating backwards-compatible S3 Gateway credentials, use this auth service (default "https://auth.storjshare.io") |
+| `-f`, `--force`         | Force overwrite an existing saved access                                                                                |
+| `--use`                 | Switch the default access to the newly created one                                                                      |
 
 ## Global flags
 

--- a/app/dcs/api/uplink-cli/share-command/page.md
+++ b/app/dcs/api/uplink-cli/share-command/page.md
@@ -34,8 +34,8 @@ An access generated using `uplink share` with no arguments creates an access to 
 | Flag                    | Description                                                                                                     |
 | :---------------------- | :-------------------------------------------------------------------------------------------------------------- |
 | `--access string`       | the serialized access, or name of the access to use                                                             |
-| `--auth-service string` | url for shared auth service, by default                                                                         |
-| `--base-url string`     | the base url for link sharing, by default                                                                       |
+| `--auth-service string` | url for shared auth service (default "https://auth.storjshare.io")                                              |
+| `--base-url string`     | the base URL for link sharing (default "https://link.storjshare.io")                                            |
 | `--disallow-deletes`    | if true, disallow deletes                                                                                       |
 | `--disallow-lists`      | if true, disallow lists                                                                                         |
 | `--disallow-reads`      | if true, disallow reads                                                                                         |
@@ -169,15 +169,15 @@ You can also generate a URL to share your projects/buckets/objects
 {% code-group %}
 
 ```windows
-./uplink.exe share sj://cakes/ --url --not-after=none --base-url=https://link.storjshare.io
+./uplink.exe share sj://cakes/ --url --not-after=none
 ```
 
 ```linux
-uplink share sj://cakes/ --url --not-after=none --base-url=https://link.storjshare.io
+uplink share sj://cakes/ --url --not-after=none
 ```
 
 ```macos
-uplink share sj://cakes/ --url --not-after=none --base-url=https://link.storjshare.io
+uplink share sj://cakes/ --url --not-after=none
 ```
 
 {% /code-group %}
@@ -227,15 +227,15 @@ While you may share individual objects with the above linksharing instructions, 
 {% code-group %}
 
 ```windows
-./uplink.exe share --dns www.mysite.com sj://cakes/ --base-url https://link.storjshare.io
+./uplink.exe share --dns www.mysite.com sj://cakes/
 ```
 
 ```linux
-uplink share --dns www.mysite.com sj://cakes/ --base-url https://link.storjshare.io
+uplink share --dns www.mysite.com sj://cakes/
 ```
 
 ```macos
-uplink share --dns www.mysite.com sj://cakes/ --base-url https://link.storjshare.io
+uplink share --dns www.mysite.com sj://cakes/
 ```
 
 {% /code-group %}

--- a/app/dcs/code/static-site-hosting/custom-domains/page.md
+++ b/app/dcs/code/static-site-hosting/custom-domains/page.md
@@ -64,16 +64,14 @@ For this step you will execute `uplink share` for the bucket or object prefix (n
 The following placeholders should be replaced in the sample code provided below:
 
 - **_\<hostname>_**: This is your custom subdomain (sub.domain.com)
-
 - **_\<bucket>_**: The bucket you want to share
-
 - **_\<prefix>_** (optional): The path to the specific folder you want to share (this is known as a prefix)
 
 {% tabs %}
 {% tab label="Windows" %}
 
 ```powershell
-./uplink.exe share --dns <hostname> sj://<bucket>/<prefix> --base-url <linkshare url>
+./uplink.exe share --dns <hostname> sj://<bucket>/<prefix>
 ```
 
 {% /tab %}
@@ -89,7 +87,7 @@ uplink share --dns <hostname> sj://<bucket>/<prefix>
 {% tab label="macOS" %}
 
 ```shell
-uplink share --dns <hostname> sj://<bucket>/<prefix> --base-url <linkshare url>
+uplink share --dns <hostname> sj://<bucket>/<prefix>
 ```
 
 {% /tab %}

--- a/app/dcs/code/static-site-hosting/page.md
+++ b/app/dcs/code/static-site-hosting/page.md
@@ -28,7 +28,7 @@ You can use your own domain name and host your own static website on Storj
 {% tab label="Windows" %}
 
 ```Text
-./uplink.exe share --dns <hostname> sj://<bucket>/<prefix> --tls
+./uplink.exe share --dns <hostname> sj://<bucket>/<prefix> --tls --not-after=none
 ```
 
 {% /tab %}

--- a/app/dcs/code/static-site-hosting/page.md
+++ b/app/dcs/code/static-site-hosting/page.md
@@ -44,7 +44,7 @@ uplink share --dns <hostname> sj://<bucket>/<prefix> --tls --not-after=none
 {% tab label="macOS" %}
 
 ```Text
-uplink share --dns <hostname> sj://<bucket>/<prefix> --tls
+uplink share --dns <hostname> sj://<bucket>/<prefix> --tls --not-after=none
 ```
 
 {% /tab %}

--- a/app/dcs/code/static-site-hosting/page.md
+++ b/app/dcs/code/static-site-hosting/page.md
@@ -36,7 +36,7 @@ You can use your own domain name and host your own static website on Storj
 {% tab label="Linux" %}
 
 ```Text
-uplink share --dns <hostname> sj://<bucket>/<prefix> --tls
+uplink share --dns <hostname> sj://<bucket>/<prefix> --tls --not-after=none
 ```
 
 {% /tab %}

--- a/app/dcs/code/static-site-hosting/page.md
+++ b/app/dcs/code/static-site-hosting/page.md
@@ -19,16 +19,16 @@ You can use your own domain name and host your own static website on Storj
 
 ## Part 1: Uplink CLI
 
-1.  Download the uplink binary ([](docId:h3RyJymEIi4gf2S9wVJg8)) and upload your static site files to Storj DCS. You may also upload your files in any other manner, but you will need the Uplink CLI for the remaining steps.
+1. Download the uplink binary ([](docId:h3RyJymEIi4gf2S9wVJg8)) and upload your static site files to Storj DCS. You may also upload your files in any other manner, but you will need the Uplink CLI for the remaining steps.
 
-2.  Share the bucket or object prefix (not individual objects) that will be the root of your website/subdomain. At the root, name your home page `index.html`. The website will serve the index.html file automatically e.g. `http://www.example.test` and `http://www.example.test/index.html` will serve the same content. Anything shared with `--dns` will be _readonly_ and available _publicly_ (no secret key needed).
+2. Share the bucket or object prefix (not individual objects) that will be the root of your website/subdomain. At the root, name your home page `index.html`. The website will serve the index.html file automatically e.g. `http://www.example.test` and `http://www.example.test/index.html` will serve the same content. Anything shared with `--dns` will be _readonly_ and available _publicly_ (no secret key needed).
 3. Finally, you can optionally add the `--tls` flag in order to return an additional DNS entry used for securing your domain with TLS.
 
 {% tabs %}
 {% tab label="Windows" %}
 
 ```Text
-./uplink.exe share --dns <hostname> sj://<bucket>/<prefix> --base-url <linkshare url> --tls
+./uplink.exe share --dns <hostname> sj://<bucket>/<prefix> --tls
 ```
 
 {% /tab %}
@@ -36,7 +36,7 @@ You can use your own domain name and host your own static website on Storj
 {% tab label="Linux" %}
 
 ```Text
-uplink share --dns <hostname> sj://<bucket>/<prefix> --base-url <linkshare url> --tls
+uplink share --dns <hostname> sj://<bucket>/<prefix> --tls
 ```
 
 {% /tab %}
@@ -44,7 +44,7 @@ uplink share --dns <hostname> sj://<bucket>/<prefix> --base-url <linkshare url> 
 {% tab label="macOS" %}
 
 ```Text
-uplink share --dns <hostname> sj://<bucket>/<prefix> --base-url <linkshare url> --tls
+uplink share --dns <hostname> sj://<bucket>/<prefix> --tls
 ```
 
 {% /tab %}

--- a/app/dcs/third-party-tools/docker/page.md
+++ b/app/dcs/third-party-tools/docker/page.md
@@ -112,7 +112,7 @@ uplink cp manifest.json sj://registry/v2/elek/herbsttag/manifests/sha256:be9eeb0
 Now we are almost there. There are two remaining parts. First, we need to register a custom domain for our _sj://registry_ bucket. The exact process is documented in [](docId:GkgE6Egi02wRZtyryFyPz), in short, an uplink command can be used to save the access grant and assign it to a domain:
 
 ```bash
-uplink share --public sj://registry/ --base-url https://link.storjshare.io --dns registry.anzix.net --auth-service https://auth.storjshare.io
+uplink share --public sj://registry/ --dns registry.anzix.net
 ```
 
 The command returns all the important information to modify the DNS zones. The usage of this information depends on the DNS registrar.


### PR DESCRIPTION
base-url and auth-service already have defaults, so we don't need to use them in the example commands and it will be less confusing to the user.