### PR TITLE
Fix per-month misunderstanding of egress cost

### DIFF
--- a/app/dcs/migrate/page.md
+++ b/app/dcs/migrate/page.md
@@ -10,7 +10,7 @@ Here are some primary advantages:
 
 | Feature                                                                                                                   | Description                                                                                                        |
 | ------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| [Cost Efficiency](docId:59T_2l7c1rvZVhI8p91VX)                                                                            | Storage as low as $4.00 per TB per month with $7.00 per TB per month for egress.                                   |
+| [Cost Efficiency](docId:59T_2l7c1rvZVhI8p91VX)                                                                            | Storage as low as $4.00 per TB per month with $7.00 per TB for egress.                                   |
 | [Multi-region](docId:eem7iong0aSh7ahbich5)                                                                                | Multi-region cloud object storage for all data distributed to tens of thousands of Storage nodes around the world. |
 | [CDN-like Performance](https://www.storj.io/blog/why-todays-cloud-storage-has-inconsistent-performance-and-how-to-fix-it) | No need to add on costs for CDNs, thanks to Storj's global distribution of data nodes                              |
 

--- a/app/dcs/pricing/page.md
+++ b/app/dcs/pricing/page.md
@@ -14,7 +14,7 @@ metadata:
 
 {% youtube-embed videoId="9uhX0X3ZW2c" /%}
 
-The price for object storage is as low as $4.00 per TB per month with $7.00 per TB per month for egress.
+The price for object storage is as low as $4.00 per TB per month with $7.00 per TB for egress.
 
 The following table lists the types of metered services that appear in billing and usage user interfaces as well as invoices:
 

--- a/app/node/payouts/page.md
+++ b/app/node/payouts/page.md
@@ -38,15 +38,15 @@ Storage Node Fees will not be paid for the following Storage Node usage:
 
 The following table includes the current Storj Satellite payout rates.
 
-| **Payment Category**  | **Rates as of Dec 1st, 2023** |
-| --------------------- | ----------------------------- |
-| Storage (per TB Mo)   | $1.50                         |
-| Egress (per TB)       | $2.00                         |
-| Audit/Repair (per TB) | $2.00                         |
+| **Payment Category**       | **Rates as of Dec 1st, 2023** |
+| ---------------------      | ----------------------------- |
+| Storage (per TB per Month) | $1.50                         |
+| Egress (per TB)            | $2.00                         |
+| Audit/Repair (per TB)      | $2.00                         |
 
 All payments are made pursuant to the terms specified in the [Node Operator Terms & Conditions](https://www.storj.io/node-operator-terms-conditions).
 
-For a detailed understanding of how TB is defined, please see [here](docId:59T_2l7c1rvZVhI8p91VX#object-storage).
+For a detailed understanding of how TB is defined, please see [](docId:59T_2l7c1rvZVhI8p91VX#object-storage).
 
 ## Related FAQ
 

--- a/app/page.md
+++ b/app/page.md
@@ -29,7 +29,7 @@ Some of the main Storj features include:
 | [S3 Compatibility](docId:eZ4caegh9queuQuaazoo)       | Change the endpoint and credentials with an S3-compatible tool of your choice and you’ll be up and running in minutes.               |
 | [Third-party tools](docId:REPde_t8MJMDaE2BU8RfQ)     | Dozen of compatible tools allowing backups, transfering large files, file management, content delivery, scientific data, and more!   |
 | [End-to-End Encryption](docId:uuhN7eyr1a8P3l_vzdnDk) | Own your data with default encryption and user-assigned access grants so no one can view or compromise your data without permission. |
-| [Cost Efficiency](docId:59T_2l7c1rvZVhI8p91VX)       | Storage as low as $4.00 per TB per month with $7.00 per TB per month for egress.                                                     |
+| [Cost Efficiency](docId:59T_2l7c1rvZVhI8p91VX)       | Storage as low as $4.00 per TB per month with $7.00 per TB for egress.                                                     |
 | [Multi-region](docId:eem7iong0aSh7ahbich5)           | Multi-region cloud object storage for all data distributed to tens of thousands of Storage nodes around the world.                   |
 | [Open Source](https://github.com/storj)              | Take advantage of absolute transparency through our open source code. You are not locked-in to our technology or cost structure.     |
 


### PR DESCRIPTION
This PR replaces all instances of "$7.00 per TB per month for egress" with "$7.00 per TB for egress". Egress is instantaneous, and not per-month.

### Futher Explanation

* Storage costs are "$x per TB per month", aka "$x per TB-month", because you get charged that for each additional month you store data.
* Egress costs are charged any time you egress the data. If you egress the data once on 2024-01-01, and again on 2024-01-02, you get charged twice, back-to-back.
* Thus, egress cost units are per "amount egressed", and have no concept of time in the units.

### Notes
* This misunderstanding is not present (i.e., is correct) on the [Storj pricing page](https://www.storj.io/pricing).
