### PR TITLE
casing and broken link

### DIFF
--- a/app/dcs/third-party-tools/iconik/page.md
+++ b/app/dcs/third-party-tools/iconik/page.md
@@ -1,5 +1,5 @@
 ---
-title: Iconik
+title: iconik
 docId: DOrHKPnU0WwmIG7LX4Pfg
 tags:
   - file-management
@@ -7,38 +7,38 @@ redirects:
   - /dcs/iconik-integration
   - /dcs/how-tos/iconik-integration-guide
 metadata:
-  title: Guide to Integrating Iconik with Storj
+  title: Guide to Integrating iconik with Storj
   description:
-    Learn to integrate Storj with Iconik, a cloud media management software.
+    Learn to integrate Storj with iconik, a cloud media management software.
     Leverage benefits like collaborative editing, file aggregation and cost savings.
     Topics covered include account creation, bucket creation and S3 credentials generation.
 ---
 
-[Iconik](https://www.iconik.io/) is a cloud media management and collaboration software that gathers and organizes media from multiple storage locations. Iconik has powerful features that allow users to find, share, and collaborate on media from anywhere in the world. Iconik is web-based and runs in the cloud, using its Iconik Storage Gateway (ISG) to manage and track files while allowing users to bring their own storage.
+[iconik](https://www.iconik.io/) is a cloud media management and collaboration software that gathers and organizes media from multiple storage locations. iconik has powerful features that allow users to find, share, and collaborate on media from anywhere in the world. iconik is web-based and runs in the cloud, using its iconik Storage Gateway (ISG) to manage and track files while allowing users to bring their own storage.
 
-## Advantages of Iconik with Storj
+## Advantages of iconik with Storj
 
-Iconik is easy to use and intuitive with a clean and intuitive platform. It organizes your media by making it searchable.
+iconik is easy to use and intuitive with a clean and intuitive platform. It organizes your media by making it searchable.
 
-1.  **Edit, manage, and collaborate on files in a feature-rich environment.** Storj integration with Iconik allows multiple users from different locations to view and edit your files on Storj simultaneously. Even parties who do not use Iconik can be invited to collaborate on documents in Iconik. Iconik also provides fine control of data sharing, allowing you to remove shares and add a time limit on shares.
+1.  **Edit, manage, and collaborate on files in a feature-rich environment.** Storj integration with iconik allows multiple users from different locations to view and edit your files on Storj simultaneously. Even parties who do not use iconik can be invited to collaborate on documents in iconik. iconik also provides fine control of data sharing, allowing you to remove shares and add a time limit on shares.
 
-2.  **Aggregates files from multiple cloud storages.** If Storj is only one part of your storage solution, Iconik makes it easy to aggregate your files from multiple storage providers.
+2.  **Aggregates files from multiple cloud storages.** If Storj is only one part of your storage solution, iconik makes it easy to aggregate your files from multiple storage providers.
 
 3.  **Cost Savings.** Adds editing and sharing features to your Storj data, creating feature-rich storage and while maintaining low costs for the storage itself.
 
 ## Integration
 
-To integrate Storj storage with Iconik, you will mount your cloud storage in Iconik's Admin section using S3 credentials.
+To integrate Storj storage with iconik, you will mount your cloud storage in iconik's Admin section using S3 credentials.
 
-Iconik integrates with any S3-compatible cloud storage platform.
+iconik integrates with any S3-compatible cloud storage platform.
 
 To complete the integration, you will need:
 
 - A Storj account - sign up here <https://storj.io/signup?partner=iconik> or go to <https://storj.io/login> if you already have an account.
 
-- An Iconik account.
+- An iconik account.
 
-Iconik is compatible with Windows, Mac, and Linux OS. To request a trial, visit <https://www.iconik.io/trial>.
+iconik is compatible with Windows, Mac, and Linux OS. To request a trial, visit <https://www.iconik.io/trial>.
 
 ---
 
@@ -124,23 +124,23 @@ In order to see the data uploaded to your bucket in the web console, you must un
 
 ---
 
-## Integrating Iconik with Storj
+## Integrating iconik with Storj
 
-To complete the integration, you will need the S3 credentials created in the previous steps and access to an Iconik account.
+To complete the integration, you will need the S3 credentials created in the previous steps and access to an iconik account.
 
-### Iconik Access
+### iconik Access
 
-To sign in to your Iconik account, visit [https://iconik.io/](https://app.iconik.io/) and click Sign In. This takes you to <https://app.iconik.io/> from where you can enter your credentials.
+To sign in to your iconik account, visit [https://iconik.io/](https://app.iconik.io/) and click Sign In. This takes you to <https://app.iconik.io/> from where you can enter your credentials.
 
 ![](https://link.storjshare.io/raw/jua7rls6hkx5556qfcmhrqed2tfa/docs/images/W_L58KzUqW4fiZ9RTNCul_image.png)
 
-If you do not have an Iconik account, you must request a trial by clicking Request Trial on the home page or filling out the contact form at [https://www.iconik.io/trial.](https://www.iconik.io/trial)
+If you do not have an iconik account, you must request a trial by clicking Request Trial on the home page or filling out the contact form at [https://www.iconik.io/trial.](https://www.iconik.io/trial)
 
 ![](https://link.storjshare.io/raw/jua7rls6hkx5556qfcmhrqed2tfa/docs/images/6fx_6jRseVAUIazaaTp9l_image.png)
 
-### Add New Storage in Iconik
+### Add New Storage in iconik
 
-1\. From the Iconik app landing page, click on ADMIN in the top navigation bar.
+1\. From the iconik app landing page, click on ADMIN in the top navigation bar.
 
 ![](https://link.storjshare.io/raw/jua7rls6hkx5556qfcmhrqed2tfa/docs/images/rhokM20s1IZ30eoBgNcRQ_admin1.png)
 
@@ -154,7 +154,7 @@ If you do not have an Iconik account, you must request a trial by clicking Reque
 
 4\. In the pop-up screen, you will enter all of the relevant information about your storage, including the S3 credentials you have saved from the previous section of this tutorial. Fill out the fields as directed below:
 
-1.  **Name**: What you will call this storage in the Iconik app. For example, "storj-bucket".
+1.  **Name**: What you will call this storage in the iconik app. For example, "storj-bucket".
 
 2.  **Description**: An optional brief description of your storage space.
 
@@ -166,13 +166,13 @@ If you do not have an Iconik account, you must request a trial by clicking Reque
 
 6.  **Secret Key**: Enter the secret key from the S3 credentials you generated in Storj.
 
-7.  **Bucket**: Enter the name of the bucket you want Iconik to access in Storj. In this case, the bucket is the "iconik" bucket you created earlier.
+7.  **Bucket**: Enter the name of the bucket you want iconik to access in Storj. In this case, the bucket is the "iconik" bucket you created earlier.
 
 8.  **Path**: The root path of your cloud storage. Normally left empty.
 
 9.  **Region**: Your region. For example, "us-east-1".
 
-10. **Endpoint**: Iconik sets the default to the AWS endpoint, but any S3 compatible storage will work. Put the Storj corresponding http(s)-endpoint here, https\://gateway.storjshare.io
+10. **Endpoint**: iconik sets the default to the AWS endpoint, but any S3 compatible storage will work. Put the Storj corresponding http(s)-endpoint here, https\://gateway.storjshare.io
 
 11. **Use Acceleration**: This feature only applies to AWS storage and should be ignored.
 
@@ -218,6 +218,16 @@ Returning to the **_Storages_** section, you will see the new storage listed. Cl
 
 ![](https://link.storjshare.io/raw/jua7rls6hkx5556qfcmhrqed2tfa/docs/images/masloLmwj8xPFE5-K-eCV_image.png)
 
-### Testing your Storj storage in Iconik
+### Testing your Storj storage in iconik
 
-All storage files are accessible from the main page of the Iconik app. When you add files to your iconik bucket in Storj, they become available in Iconik's web app.
+All storage files are accessible from the main page of the iconik app. When you add files to your iconik bucket in Storj, they become available in iconik's web app.
+
+{% callout type="info"  %}
+If using [iconik Agent](https://www.iconik.io/agent) or [iconik Storage Gateway](https://app.iconik.io/help/pages/isg/), you may benefit from optimizing your configuration for Storj.
+ - In iconik Storage Gateway, set `upload-chunk-size = 67108864`.
+   Consider adjusting `file-upload-parallel-uploads-num` and `file-upload-parallel-uploads-threads-num` for optimal performance.
+   See [ISG Advanced Options](https://app.iconik.io/help/pages/isg/advanced_options) for more information.
+ - In iconik Agent, set `"chunkSize": 67108864`.
+   Consider adjusting `numConcurrentChunks` and `numConcurrentUploads` for optimal performance.
+   See [Configuring iconik Agent](https://app.iconik.io/help/pages/agent/configuration) for more information.
+{% /callout %}


### PR DESCRIPTION
Iconik is always spelled with a lowercase "i" on their website.
Added section for performance tuning.