### PR TITLE
added warning to apply execution permissions for `bin` subfolder

### DIFF
--- a/app/(docs)/node/get-started/install-node-software/cli/storage-node/page.md
+++ b/app/(docs)/node/get-started/install-node-software/cli/storage-node/page.md
@@ -37,7 +37,7 @@ The writeability and readability checks are performed on the storage location, n
 **Linux Users:** You **must** static mount via /etc/fstab. Failure to do so will put you in high risk of failing audits and getting disqualified. Here's how to do that: [](docId:nZeFxmawYPdgkwUPy6f9s)
 {% /callout %}
 
-{% callout type="warning"  %}
+{% callout type="info"  %}
 You need to allow an execution for the `bin` subfolder in your storage location
 Replace the `<storage-dir>` with your parameter.
 
@@ -61,7 +61,7 @@ docker run --rm -e SETUP="true" \
 
 {% tab label="macOS" %}
 
-{% callout type="warning"  %}
+{% callout type="info"  %}
 You need to allow an execution for the `bin` subfolder in your storage location. 
 Replace the `<storage-dir>` with your parameter.
 

--- a/app/(docs)/node/get-started/install-node-software/cli/storage-node/page.md
+++ b/app/(docs)/node/get-started/install-node-software/cli/storage-node/page.md
@@ -41,7 +41,7 @@ The writeability and readability checks are performed on the storage location, n
 You need to allow an execution for the `bin` subfolder in your storage location
 Replace the `<storage-dir>` with your parameter.
 
-```
+```shell
 mkdir -p <storage-dir>/bin
 chmod +x <storage-dir>/bin
 ```
@@ -65,7 +65,7 @@ docker run --rm -e SETUP="true" \
 You need to allow an execution for the `bin` subfolder in your storage location. 
 Replace the `<storage-dir>` with your parameter.
 
-```
+```shell
 mkdir -p <storage-dir>/bin
 chmod +x <storage-dir>/bin
 ```

--- a/app/(docs)/node/get-started/install-node-software/cli/storage-node/page.md
+++ b/app/(docs)/node/get-started/install-node-software/cli/storage-node/page.md
@@ -37,6 +37,16 @@ The writeability and readability checks are performed on the storage location, n
 **Linux Users:** You **must** static mount via /etc/fstab. Failure to do so will put you in high risk of failing audits and getting disqualified. Here's how to do that: [](docId:nZeFxmawYPdgkwUPy6f9s)
 {% /callout %}
 
+{% callout type="warning"  %}
+You need to allow an execution for the `bin` subfolder in your storage location
+Replace the `<storage-dir>` with your parameter.
+
+```
+mkdir -p <storage-dir>/bin
+chmod +x <storage-dir>/bin
+```
+{% /callout %}
+
 1.  Copy the command into a plain text editor like a `nano`:
 
 ```shell
@@ -50,6 +60,16 @@ docker run --rm -e SETUP="true" \
 {% /tab %}
 
 {% tab label="macOS" %}
+
+{% callout type="warning"  %}
+You need to allow an execution for the `bin` subfolder in your storage location. 
+Replace the `<storage-dir>` with your parameter.
+
+```
+mkdir -p <storage-dir>/bin
+chmod +x <storage-dir>/bin
+```
+{% /callout %}
 
 1.  Copy the command into a plain text editor (do not use any word processors include Notes):
 


### PR DESCRIPTION
https://forum.storj.io/t/storagenode-docker-update-changes-to-binaries-location-for-persistence-between-restarts/27937