### PR TITLE
removed requirement to have an `exec` permission for the data location

### DIFF
--- a/app/(docs)/node/get-started/install-node-software/cli/storage-node/page.md
+++ b/app/(docs)/node/get-started/install-node-software/cli/storage-node/page.md
@@ -34,17 +34,7 @@ The writeability and readability checks are performed on the storage location, n
 {% tabs %}
 {% tab label="Linux" %}
 {% callout type="danger"  %}
-**Linux Users:** You **must** static mount via /etc/fstab. Failure to do so will put you in high risk of failing audits and getting disqualified. The mount options must include `exec` permission. Here's how to do that: [](docId:nZeFxmawYPdgkwUPy6f9s)
-{% /callout %}
-
-{% callout type="info"  %}
-You need to allow an execution for the `bin` subfolder in your storage location. The disk mount options must include `exec` permission.
-Replace the `<storage-dir>` with your parameter.
-
-```shell
-mkdir -p <storage-dir>/bin
-chmod +x <storage-dir>/bin
-```
+**Linux Users:** You **must** static mount via /etc/fstab. Failure to do so will put you in high risk of failing audits and getting disqualified. Here's how to do that: [](docId:nZeFxmawYPdgkwUPy6f9s)
 {% /callout %}
 
 1.  Copy the command into a plain text editor like a `nano`:

--- a/app/(docs)/node/get-started/prerequisites/page.md
+++ b/app/(docs)/node/get-started/prerequisites/page.md
@@ -48,7 +48,7 @@ Ubuntu - 64-bit version of one of these Ubuntu versions:
 - Bionic 18.04 (LTS) or later
 
 > **Make sure you use static mount for your hard drive via**
-> **/etc/fstab and drive is mounted with `exec` permission**:
+> **/etc/fstab**:
 > See [](docId:nZeFxmawYPdgkwUPy6f9s).
 
 {% /tab %}


### PR DESCRIPTION
Related to:
* https://github.com/storj/storagenode-docker/pull/25
* https://github.com/storj/storagenode-docker/issues/23

Some restricted systems (e.g. NASes) cannot be adapted to apply `exec` permission to the data location