### PR TITLE
Fix broken link for 'Download and Install Instructions'

### DIFF
--- a/app/(docs)/object-mount/getting-started/download-install/page.md
+++ b/app/(docs)/object-mount/getting-started/download-install/page.md
@@ -14,7 +14,7 @@ All of our releases are [available on GitHub](https://github.com/cunoFS/cunoFS/r
 
 ## Downloading and installing
 
-[Download and Install Instructions](./installation)
+[Download and Install Instructions](../installation)
 
 ## Licenses and activation
 For licensing, please schedule a [discovery call](https://meetings.hubspot.com/tom1581/storj-object-mount-discovery-meeting?uuid=7d69a8eb-87d2-4971-aef9-9ea2b1073e7a).


### PR DESCRIPTION
Fixed broken link.

On https://storj.dev/object-mount/getting-started/download-install#downloading-and-installing, there is a link labeled  'Download and Install Instructions' which currently points to https://storj.dev/object-mount/getting-started/installation, resulting in a 404 error.

It likely should point to:
https://storj.dev/object-mount/installation