### PR TITLE
Update MacOS Install Instructions

### DIFF
--- a/app/(docs)/object-mount/installation/mac/page.md
+++ b/app/(docs)/object-mount/installation/mac/page.md
@@ -8,9 +8,9 @@ metadata:
     MacOS Installation Instructions
 
 ---
-A fully native Mac client is coming soon!
+A fully native Mac client is in private beta, with a public beta available soon!
 
-You can currently install Object Mount on your Mac directly, or inside a container. Installing Object Mount on your Mac directly will allow you to use `cuno-mac`, our handy tool for launching Linux containers that automatically have your local installation of Object Mount available inside them.
+However, if you would like to run the Linux version on your Mac, you can currently install inside a container. Installing Object Mount on your Mac directly will allow you to use `cuno-mac`, our handy tool for launching Linux containers that automatically have your local installation of Object Mount available inside them.
 
 {% callout type="note"  %}
 For those on Apple Silicon (ARM) Macs, macOS 13.0 Ventura or later is required.


### PR DESCRIPTION
Called out native macos installer is in beta, and the following instructions are for running the LInux version inside a container.