### PR TITLE
trying to capture redirect

### DIFF
--- a/app/(docs)/object-mount/linux/getting-started/configuring-credentials/page.md
+++ b/app/(docs)/object-mount/linux/getting-started/configuring-credentials/page.md
@@ -1,6 +1,8 @@
 ---
 title: Configuring Credentials
 docId: heefureS2iubahpi
+redirects:
+  - /object-mount?platform=linux&help=credentials
 weight: 4
 metadata:
   title: Configuring Credentials

--- a/app/(docs)/object-mount/linux/getting-started/configuring-credentials/page.md
+++ b/app/(docs)/object-mount/linux/getting-started/configuring-credentials/page.md
@@ -4,6 +4,7 @@ docId: heefureS2iubahpi
 redirects:
   - /object-mount/?platform=linux&help=credentials
   - /object-mount?platform=linux&help=credentials
+  - /object-mount/linux/credentials
 weight: 4
 metadata:
   title: Configuring Credentials

--- a/app/(docs)/object-mount/linux/getting-started/configuring-credentials/page.md
+++ b/app/(docs)/object-mount/linux/getting-started/configuring-credentials/page.md
@@ -2,7 +2,7 @@
 title: Configuring Credentials
 docId: heefureS2iubahpi
 redirects:
-  - /object-mount?platform=linux&help=credentials
+  - /object-mount/?platform=linux&help=credentials
 weight: 4
 metadata:
   title: Configuring Credentials

--- a/app/(docs)/object-mount/linux/getting-started/configuring-credentials/page.md
+++ b/app/(docs)/object-mount/linux/getting-started/configuring-credentials/page.md
@@ -3,6 +3,7 @@ title: Configuring Credentials
 docId: heefureS2iubahpi
 redirects:
   - /object-mount/?platform=linux&help=credentials
+  - /object-mount?platform=linux&help=credentials
 weight: 4
 metadata:
   title: Configuring Credentials


### PR DESCRIPTION
https://storj.slack.com/archives/C0814L9E6HW/p1751299187050449?thread_ts=1751296394.213529&cid=C0814L9E6HW

> My thinking is that this front page is not exactly "help" on the issue.
Looking at that front page I have no idea where to go for credentials issues.
Could we have a ? suffix off the main page that redirects to the correct location when it works, but stays on the main page when it is broken?
eg ?platform=linux&help=credentials