### PR TITLE
docs: Remove blockquote from warning

### DIFF
--- a/src/components/Prose.jsx
+++ b/src/components/Prose.jsx
@@ -19,7 +19,9 @@ export function Prose({ as: Component = 'div', className, ...props }) {
         // pre
         'prose-pre:rounded-xl prose-pre:bg-storj-black prose-pre:shadow-lg dark:prose-pre:bg-slate-800/60 dark:prose-pre:shadow-none dark:prose-pre:ring-1 dark:prose-pre:ring-slate-300/10',
         // hr
-        'dark:prose-hr:border-slate-800'
+        'dark:prose-hr:border-slate-800',
+        // blockquote
+        'dark:prose-blockquote:text-slate-300'
       )}
       {...props}
     />


### PR DESCRIPTION
Remove blockquote from the text inside a warning box because it makes very hard to read the text in dark mode.

Before
<img width="1931" height="1156" alt="image" src="https://github.com/user-attachments/assets/20430ab3-412b-4c7b-800a-fe754b0f9078" />

After
<img width="1951" height="1080" alt="image" src="https://github.com/user-attachments/assets/2d0f1e47-1d7b-4b5f-8f92-6c5d30cee05b" />
