### PR TITLE
increased UDP buffer for QUIC to 7.5MB

### DIFF
--- a/app/(docs)/node/get-started/quic-requirements/linux-configuration-for-udp/page.md
+++ b/app/(docs)/node/get-started/quic-requirements/linux-configuration-for-udp/page.md
@@ -13,15 +13,15 @@ Our software attempts to increase the UDP receive buffer size. However, on Linux
 We recommend increasing the maximum buffer size by running the following to increase it to \~2.5MB.
 
 ```bash
-sysctl -w net.core.rmem_max=2500000
+sysctl -w net.core.rmem_max=7500000
 ```
 
 To make this value persistent across reboots, run the following instead (as root):
 
 ```bash
-echo "net.core.rmem_max=2500000" >> /etc/sysctl.d/udp_buffer.conf
+echo "net.core.rmem_max=7500000" >> /etc/sysctl.d/udp_buffer.conf
 
-sysctl -w net.core.rmem_max=2500000
+sysctl -w net.core.rmem_max=7500000
 ```
 
 Reference: [udp receive buffer size in quic-go](https://github.com/lucas-clemente/quic-go/wiki/UDP-Receive-Buffer-Size)

--- a/app/(docs)/node/get-started/quic-requirements/macosfreebsd-configuration-for-udp/page.md
+++ b/app/(docs)/node/get-started/quic-requirements/macosfreebsd-configuration-for-udp/page.md
@@ -10,7 +10,7 @@ UDP transfers on high-bandwidth connections can be limited by the size of the UD
 
 Our software attempts to increase the UDP receive buffer size. However, on macOS/FreeBSD, an application is only allowed to increase the buffer size up to a maximum value set in the kernel, and the default maximum value is too small for high-bandwidth UDP transfers.
 
-We recommend increasing the maximum buffer size by running the following to increase it to \~2.5MB. Accordingly [article of Cameron Sparr](https://medium.com/@CameronSparr/increase-os-udp-buffers-to-improve-performance-51d167bb1360), on BSD/Darwin systems you need to add about a 15% padding to the kernel limit socket buffer, i.e. `2.5MB * 1.15 = 2.875MB`.
+We recommend increasing the maximum buffer size by running the following to increase it to \~7.5MB. Accordingly [article of Cameron Sparr](https://medium.com/@CameronSparr/increase-os-udp-buffers-to-improve-performance-51d167bb1360), on BSD/Darwin systems you need to add about a 15% padding to the kernel limit socket buffer, i.e. `7.5MB * 1.15 = 8.625MB`.
 
 You may check the current UDP/IP buffer limit by typing the following command:
 
@@ -18,14 +18,14 @@ You may check the current UDP/IP buffer limit by typing the following command:
 sysctl kern.ipc.maxsockbuf
 ```
 
-If the value is less than 2875000 bytes you should add the following lines to the `/etc/sysctl.d/udp_buffer.conf` file (execute as root):
+If the value is less than 8625000 bytes you should add the following lines to the `/etc/sysctl.d/udp_buffer.conf` file (execute as root):
 
 ```shell
-echo "kern.ipc.maxsockbuf=2875000" >> /etc/sysctl.d/udp_buffer.conf
+echo "kern.ipc.maxsockbuf=8625000" >> /etc/sysctl.d/udp_buffer.conf
 ```
 
 Changes to `/etc/sysctl.d/udp_buffer.conf` do not take effect until reboot. To update the values immediately, type the following commands as root:
 
 ```shell
-sudo sysctl -w kern.ipc.maxsockbuf=2875000
+sudo sysctl -w kern.ipc.maxsockbuf=8625000
 ```


### PR DESCRIPTION
https://forum.storj.io/t/changes-to-the-udp-buffer-size-for-quic-needed/30362/9?u=alexey

I can confirm on my node
```
$ grep "increase receive buffer size" /mnt/x/storagenode2/storagenode.log | tail
2025-07-02T16:15:34Z    INFO    failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 7168 kiB, got: 416 kiB). See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for details.   {"Process": "storagenode"}
2025-07-09T01:40:46Z    INFO    failed to sufficiently increase receive buffer size (was: 208 kiB, wanted: 7168 kiB, got: 416 kiB). See https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes for details.   {"Process": "storagenode"}
```