### PR TITLE
Starter package has an expiration date

### DIFF
--- a/app/(docs)/dcs/pricing/page.md
+++ b/app/(docs)/dcs/pricing/page.md
@@ -127,7 +127,7 @@ This helps cover the cost of payment processing and basic operations so we can c
 
 - Any monthly usage that results in an invoice less than $5 will result in the minimum usage fee.
 - If your usage exceeds $5 per month, you will not be charged a minimum usage fee.
-- If you prepay via a partner before August 1, 2025, you will not be charged a minimum usage fee while your account has funds.
+- If you bought a starter package via a partner before August 1, 2025, you will not be charged a minimum usage fee until your starter package expires. The starter package expires one year from purchase or when the starter package credits have been fully used.
 - If you pay with STORJ token, you will not be charged a minimum usage fee.
 
 ## Project limits


### PR DESCRIPTION
 If you bought a starter package via a partner before August 1, 2025, you will not be charged a minimum usage fee until your starter package expires. The starter package expires one year from purchase or when the starter package credits have been fully used.