### PR TITLE
Update legacy bucket constraints information

### DIFF
--- a/app/(docs)/dcs/api/s3/s3-compatibility/page.md
+++ b/app/(docs)/dcs/api/s3/s3-compatibility/page.md
@@ -145,7 +145,7 @@ This is currently supported in Gateway-MT only.
 Specifies the region (or tier) where the object data for a bucket is stored.
 
 {% callout type="info" %}
-Buckets in projects created **before November 1, 2025** use legacy constraints (`global`, `us-select-1`) unless they are migrated to the new tiers.
+Buckets in projects created **before November 1, 2025** use legacy constraints (`global`, `us-select-1`).
 
 For more information:
 - [Tiered Pricing](docId:mqRRgT,hL*dk3zNT)


### PR DESCRIPTION
Removed mention of migration to new tiers for legacy buckets.